### PR TITLE
Update ArgoCD deployment workflow for improved flexibility

### DIFF
--- a/.github/workflows/deploy-argocd-v4.yaml
+++ b/.github/workflows/deploy-argocd-v4.yaml
@@ -159,7 +159,7 @@ jobs:
         if: ${{ inputs.argocd-wait }}
         shell: bash
         env:
-          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.argocd-auth-token }}
           ARGOCD_GRPC_KEEP_ALIVE_MIN: ${{ inputs.grpc-keep-alive-min }}
         run: |
           command="argocd app wait ${{ inputs.app-namespace }}/${{ inputs.application-name }} \

--- a/.github/workflows/deploy-argocd-v4.yaml
+++ b/.github/workflows/deploy-argocd-v4.yaml
@@ -1,0 +1,152 @@
+name: Deploy on ArgoCD
+
+on:
+  workflow_call:
+    inputs:
+      argocd-additional-options:
+        required: false
+        type: string
+        description: Additional argocd options. Can be --helm-set to override values, or --sync-options, etc.
+
+      argocd-app-name:
+        required: false
+        type: string
+        description: Application name
+        default: "${{ github.event.repository.name }}"
+
+      argocd-chart-path:
+        required: false
+        type: string
+        description: Helm chart path
+        default: "chart"
+
+      argocd-chart-repo:
+        required: true
+        type: string
+        description: Which repo the helm chart is located
+        default: "git@github.com:${{ github.repository }}"
+
+      argocd-http-retry-max:
+        required: false
+        type: string
+        description: Http max retries
+        default: "3"
+
+      argocd-revision:
+        required: false
+        type: string
+        description: Github ref
+        default: HEAD
+
+      argocd-skip-sync:
+        required: false
+        type: boolean
+        description: Should skip sync step
+        default: false
+
+      argocd-sync-timeout:
+        required: false
+        type: string
+        description: ArgoCD sync timeout
+        default: "300"
+
+      argocd-values-file:
+        required: false
+        type: string
+        description: Values yaml file
+        default: "values.yaml"
+
+      argocd-wait:
+        required: false
+        type: boolean
+        description: Wait for application to be healthy and synced after deploy
+        default: true
+
+      argocd-wait-timeout:
+        required: false
+        type: string
+        description: ArgoCD app wait timeout in seconds
+        default: "300"
+
+      environment:
+        required: true
+        type: string
+        description: Environment
+
+      git-runner-container:
+        required: false
+        type: string
+        description: Github runner container
+        default: "public.ecr.aws/u1y2d3y2/cd-argocd:2.9.0"
+
+      image-tag:
+        required: true
+        type: string
+        description: Docker image tag
+
+      namespace:
+        required: true
+        type: string
+        description: Destination namespace
+
+      runs-on:
+        required: false
+        type: string
+        description: OS machine
+        default: "ubuntu-24.04"
+
+    secrets:
+      ARGOCD_AUTH_TOKEN:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ${{ inputs.runs-on }}
+    environment: ${{ inputs.environment }}
+    container:
+      image: ${{ inputs.git-runner-container }}
+    env:
+      NAMESPACE: ${{ inputs.namespace }}
+    steps:
+      - name: Create/Update application on ArgoCD
+        shell: bash
+        run: |
+          argocd app create ${{ inputs.argocd-app-name }}  \
+            --dest-namespace ${{ env.NAMESPACE }} \
+            --dest-server ${{ vars.ARGOCD_DESTINATION_CLUSTER }} \
+            --helm-set image.tag=${{ inputs.image-tag }} \
+            --path ${{ inputs.argocd-chart-path }} \
+            --project ${{ vars.ARGOCD_PROJECT }} \
+            --repo ${{ inputs.argocd-chart-repo }} \
+            --server ${{ vars.ARGOCD_SERVER_URL }} \
+            --upsert \
+            --revision ${{ inputs.argocd-revision }} \
+            --http-retry-max ${{ inputs.argocd-http-retry-max }} \
+            --grpc-web \
+            --auth-token ${{ secrets.ARGOCD_AUTH_TOKEN }} \
+            --values ${{ inputs.argocd-values-file }} \
+            ${{ inputs.argocd-additional-options }} 
+
+      - name: Run Sync on ArgoCD
+        if: ${{ inputs.argocd-skip-sync == false }}
+        shell: bash
+        run: |
+          argocd app sync ${{ inputs.argocd-app-name }} \
+            --server ${{ vars.ARGOCD_SERVER_URL }} \
+            --force \
+            --retry-limit 3 \
+            --grpc-web \
+            --auth-token ${{ secrets.ARGOCD_AUTH_TOKEN }} \
+            --timeout ${{ inputs.argocd-sync-timeout }}
+
+      - name: Wait for ArgoCD Application Health
+        if: ${{ inputs.argocd-wait == true && inputs.argocd-skip-sync == false }}
+        shell: bash
+        run: |
+          argocd app wait ${{ inputs.argocd-app-name }} \
+            --server ${{ vars.ARGOCD_SERVER_URL }} \
+            --health \
+            --sync \
+            --grpc-web \
+            --auth-token ${{ secrets.ARGOCD_AUTH_TOKEN }} \
+            --timeout ${{ inputs.argocd-wait-timeout }}

--- a/.github/workflows/deploy-argocd-v4.yaml
+++ b/.github/workflows/deploy-argocd-v4.yaml
@@ -122,7 +122,7 @@ jobs:
           ARGOCD_AUTH_TOKEN: ${{ secrets.argocd-auth-token }}
           ARGOCD_GRPC_KEEP_ALIVE_MIN: ${{ inputs.grpc-keep-alive-min }}
         run: |
-          command="argocd app create ${{ inputs.application-name }}-${{ inputs.environment }} \
+          command="argocd app create ${{ inputs.environment }}-${{ inputs.application-name }} \
             --app-namespace ${{ inputs.app-namespace }} \
             --dest-namespace ${{ inputs.namespace }} \
             --dest-server ${{ inputs.argocd-destination-cluster }} \

--- a/.github/workflows/deploy-argocd-v4.yaml
+++ b/.github/workflows/deploy-argocd-v4.yaml
@@ -1,152 +1,175 @@
-name: Deploy on ArgoCD
+name: Deploy to ArgoCD
 
 on:
   workflow_call:
     inputs:
-      argocd-additional-options:
-        required: false
-        type: string
-        description: Additional argocd options. Can be --helm-set to override values, or --sync-options, etc.
-
-      argocd-app-name:
-        required: false
-        type: string
-        description: Application name
-        default: "${{ github.event.repository.name }}"
-
-      argocd-chart-path:
-        required: false
-        type: string
-        description: Helm chart path
-        default: "chart"
-
-      argocd-chart-repo:
+      application-name:
+        description: 'ArgoCD application name'
         required: true
         type: string
-        description: Which repo the helm chart is located
-        default: "git@github.com:${{ github.repository }}"
-
-      argocd-http-retry-max:
-        required: false
-        type: string
-        description: Http max retries
-        default: "3"
-
-      argocd-revision:
-        required: false
-        type: string
-        description: Github ref
-        default: HEAD
-
-      argocd-skip-sync:
-        required: false
-        type: boolean
-        description: Should skip sync step
-        default: false
-
-      argocd-sync-timeout:
-        required: false
-        type: string
-        description: ArgoCD sync timeout
-        default: "300"
-
-      argocd-values-file:
-        required: false
-        type: string
-        description: Values yaml file
-        default: "values.yaml"
-
-      argocd-wait:
-        required: false
-        type: boolean
-        description: Wait for application to be healthy and synced after deploy
-        default: true
-
-      argocd-wait-timeout:
-        required: false
-        type: string
-        description: ArgoCD app wait timeout in seconds
-        default: "300"
-
-      environment:
+      argocd-server-url:
+        description: 'ArgoCD server URL (e.g., argocd.example.com)'
         required: true
         type: string
-        description: Environment
-
-      git-runner-container:
-        required: false
-        type: string
-        description: Github runner container
-        default: "public.ecr.aws/u1y2d3y2/cd-argocd:2.9.0"
-
-      image-tag:
+      argocd-project:
+        description: 'ArgoCD project name'
         required: true
         type: string
-        description: Docker image tag
-
+      argocd-destination-cluster:
+        description: 'Destination cluster name (as registered in ArgoCD)'
+        required: true
+        type: string
+      repository-url:
+        description: 'Git repository URL containing the Helm chart'
+        required: true
+        type: string
+      chart-path:
+        description: 'Path to Helm chart in repository'
+        required: true
+        type: string
       namespace:
+        description: 'Kubernetes namespace to deploy to'
         required: true
         type: string
-        description: Destination namespace
-
-      runs-on:
-        required: false
+      app-namespace:
+        description: 'ArgoCD application namespace'
+        required: true
         type: string
-        description: OS machine
-        default: "ubuntu-24.04"
-
+      environment:
+        description: 'Environment name (used for values file: values-{environment}.yaml)'
+        required: true
+        type: string
+      image-tag:
+        description: 'Docker image tag to deploy (can be used in Helm values)'
+        required: true
+        type: string
+      revision:
+        description: 'Git revision to deploy (branch, tag, or commit SHA)'
+        required: false
+        default: 'HEAD'
+        type: string
+      sync-policy:
+        description: 'Sync policy: manual or auto'
+        required: false
+        default: 'manual'
+        type: string
+      argocd-wait:
+        description: 'Wait for application to be healthy and synced'
+        required: false
+        default: true
+        type: boolean
+      argocd-wait-timeout:
+        description: 'Wait timeout in seconds'
+        required: false
+        default: 300
+        type: number
+      auto-create-namespace:
+        description: 'Automatically create namespace if it does not exist'
+        required: false
+        default: false
+        type: boolean
+      auto-prune:
+        description: 'Enable automatic pruning of resources'
+        required: false
+        default: false
+        type: boolean
+      self-heal:
+        description: 'Enable self-healing of application'
+        required: false
+        default: false
+        type: boolean
+      grpc-keep-alive-min:
+        description: 'gRPC keep alive minimum time'
+        required: false
+        default: '20s'
+        type: string
+      argocd-wait-additional-args:
+        description: 'Additional arguments for argocd app wait command'
+        required: false
+        default: ''
+        type: string
+      argocd-create-app-additional-args:
+        description: 'Additional arguments for argocd app create command'
+        required: false
+        default: ''
+        type: string
     secrets:
-      ARGOCD_AUTH_TOKEN:
+      argocd-auth-token:
+        description: 'ArgoCD authentication token'
         required: true
 
 jobs:
   deploy:
-    runs-on: ${{ inputs.runs-on }}
-    environment: ${{ inputs.environment }}
-    container:
-      image: ${{ inputs.git-runner-container }}
-    env:
-      NAMESPACE: ${{ inputs.namespace }}
+    runs-on: ubuntu-latest
     steps:
-      - name: Create/Update application on ArgoCD
+      - name: Install ArgoCD CLI
         shell: bash
         run: |
-          argocd app create ${{ inputs.argocd-app-name }}  \
-            --dest-namespace ${{ env.NAMESPACE }} \
-            --dest-server ${{ vars.ARGOCD_DESTINATION_CLUSTER }} \
-            --helm-set image.tag=${{ inputs.image-tag }} \
-            --path ${{ inputs.argocd-chart-path }} \
-            --project ${{ vars.ARGOCD_PROJECT }} \
-            --repo ${{ inputs.argocd-chart-repo }} \
-            --server ${{ vars.ARGOCD_SERVER_URL }} \
+          if ! command -v argocd &> /dev/null; then
+            echo "Installing ArgoCD CLI..."
+            curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+            chmod +x argocd
+            sudo mv argocd /usr/local/bin/
+            echo "ArgoCD CLI installed successfully"
+          else
+            echo "ArgoCD CLI already installed"
+          fi
+          argocd version --client
+
+      - name: Create/Update ArgoCD Application
+        shell: bash
+        env:
+          ARGOCD_AUTH_TOKEN: ${{ secrets.argocd-auth-token }}
+          ARGOCD_GRPC_KEEP_ALIVE_MIN: ${{ inputs.grpc-keep-alive-min }}
+        run: |
+          command="argocd app create ${{ inputs.application-name }} \
+            --app-namespace ${{ inputs.app-namespace }} \
+            --dest-namespace ${{ inputs.namespace }} \
+            --dest-name ${{ inputs.argocd-destination-cluster }} \
+            --path ${{ inputs.chart-path }} \
+            --project ${{ inputs.argocd-project }} \
+            --repo ${{ inputs.repository-url }} \
+            --server ${{ inputs.argocd-server-url }} \
+            ${{ inputs.argocd-create-app-additional-args }} \
             --upsert \
-            --revision ${{ inputs.argocd-revision }} \
-            --http-retry-max ${{ inputs.argocd-http-retry-max }} \
             --grpc-web \
-            --auth-token ${{ secrets.ARGOCD_AUTH_TOKEN }} \
-            --values ${{ inputs.argocd-values-file }} \
-            ${{ inputs.argocd-additional-options }} 
+            --revision ${{ inputs.revision }} \
+            --values values-${{ inputs.environment }}.yaml"
 
-      - name: Run Sync on ArgoCD
-        if: ${{ inputs.argocd-skip-sync == false }}
-        shell: bash
-        run: |
-          argocd app sync ${{ inputs.argocd-app-name }} \
-            --server ${{ vars.ARGOCD_SERVER_URL }} \
-            --force \
-            --retry-limit 3 \
-            --grpc-web \
-            --auth-token ${{ secrets.ARGOCD_AUTH_TOKEN }} \
-            --timeout ${{ inputs.argocd-sync-timeout }}
+          if [ "${{ inputs.auto-create-namespace }}" == "true" ]; then
+            command+=" --sync-option CreateNamespace=true"
+          fi
 
-      - name: Wait for ArgoCD Application Health
-        if: ${{ inputs.argocd-wait == true && inputs.argocd-skip-sync == false }}
+          if [ "${{ inputs.auto-prune }}" == "true" ]; then
+            command+=" --auto-prune"
+          fi
+
+          if [ "${{ inputs.self-heal }}" == "true" ]; then
+            command+=" --self-heal"
+          fi
+
+          command+=" --sync-policy ${{ inputs.sync-policy }}"
+
+          echo "Creating/updating ArgoCD application..."
+          echo "Command: $command"
+          eval $command
+
+      - name: Wait for ArgoCD Application
+        if: ${{ inputs.argocd-wait }}
         shell: bash
+        env:
+          ARGOCD_AUTH_TOKEN: ${{ secrets.argocd-auth-token }}
+          ARGOCD_GRPC_KEEP_ALIVE_MIN: ${{ inputs.grpc-keep-alive-min }}
         run: |
-          argocd app wait ${{ inputs.argocd-app-name }} \
-            --server ${{ vars.ARGOCD_SERVER_URL }} \
+          command="argocd app wait ${{ inputs.app-namespace }}/${{ inputs.application-name }} \
+            --server ${{ inputs.argocd-server-url }} \
             --health \
             --sync \
             --grpc-web \
-            --auth-token ${{ secrets.ARGOCD_AUTH_TOKEN }} \
-            --timeout ${{ inputs.argocd-wait-timeout }}
+            --timeout ${{ inputs.argocd-wait-timeout }} \
+            ${{ inputs.argocd-wait-additional-args }}"
+
+          echo "Waiting for application to be healthy and synced..."
+          echo "Command: $command"
+          eval $command
+          echo "Application is healthy and synced!"

--- a/.github/workflows/deploy-argocd-v4.yaml
+++ b/.github/workflows/deploy-argocd-v4.yaml
@@ -159,7 +159,7 @@ jobs:
         if: ${{ inputs.argocd-wait }}
         shell: bash
         env:
-          ARGOCD_AUTH_TOKEN: ${{ secrets.argocd-auth-token }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
           ARGOCD_GRPC_KEEP_ALIVE_MIN: ${{ inputs.grpc-keep-alive-min }}
         run: |
           command="argocd app wait ${{ inputs.app-namespace }}/${{ inputs.application-name }} \

--- a/.github/workflows/deploy-argocd-v4.yaml
+++ b/.github/workflows/deploy-argocd-v4.yaml
@@ -122,7 +122,7 @@ jobs:
           ARGOCD_AUTH_TOKEN: ${{ secrets.argocd-auth-token }}
           ARGOCD_GRPC_KEEP_ALIVE_MIN: ${{ inputs.grpc-keep-alive-min }}
         run: |
-          command="argocd app create ${{ inputs.application-name }} \
+          command="argocd app create ${{ inputs.application-name }}-${{ inputs.environment }} \
             --app-namespace ${{ inputs.app-namespace }} \
             --dest-namespace ${{ inputs.namespace }} \
             --dest-server ${{ inputs.argocd-destination-cluster }} \

--- a/.github/workflows/deploy-argocd-v4.yaml
+++ b/.github/workflows/deploy-argocd-v4.yaml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       argocd-destination-cluster:
-        description: 'Destination cluster name (as registered in ArgoCD)'
+        description: 'Destination cluster server URL (as registered in ArgoCD)'
         required: true
         type: string
       repository-url:
@@ -125,7 +125,7 @@ jobs:
           command="argocd app create ${{ inputs.application-name }} \
             --app-namespace ${{ inputs.app-namespace }} \
             --dest-namespace ${{ inputs.namespace }} \
-            --dest-name ${{ inputs.argocd-destination-cluster }} \
+            --dest-server ${{ inputs.argocd-destination-cluster }} \
             --path ${{ inputs.chart-path }} \
             --project ${{ inputs.argocd-project }} \
             --repo ${{ inputs.repository-url }} \
@@ -134,7 +134,8 @@ jobs:
             --upsert \
             --grpc-web \
             --revision ${{ inputs.revision }} \
-            --values values-${{ inputs.environment }}.yaml"
+            --values values-${{ inputs.environment }}.yaml \
+            --helm-set image.tag=${{ inputs.image-tag }}"
 
           if [ "${{ inputs.auto-create-namespace }}" == "true" ]; then
             command+=" --sync-option CreateNamespace=true"

--- a/.github/workflows/deploy-argocd-v4.yaml
+++ b/.github/workflows/deploy-argocd-v4.yaml
@@ -162,7 +162,7 @@ jobs:
           ARGOCD_AUTH_TOKEN: ${{ secrets.argocd-auth-token }}
           ARGOCD_GRPC_KEEP_ALIVE_MIN: ${{ inputs.grpc-keep-alive-min }}
         run: |
-          command="argocd app wait ${{ inputs.app-namespace }}/${{ inputs.application-name }} \
+          command="argocd app wait ${{ inputs.app-namespace }}/${{ inputs.environment }}-${{ inputs.application-name }} \
             --server ${{ inputs.argocd-server-url }} \
             --health \
             --sync \

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+/.idea


### PR DESCRIPTION
```
### Summary of Changes
- Added a new GitHub Actions workflow for ArgoCD deployment.
- Enhanced `deploy-argocd-v4.yaml` to prepend the environment to the application name in ArgoCD commands.
- Fixed secret references and naming inconsistencies (`ARGOCD_AUTH_TOKEN` and `argocd-auth-token`).
- Updated ArgoCD workflow to use the destination server URL (`--dest-server`) instead of `--dest-name`.
- Adjusted deployment workflows in `ci-staging.yaml` for better flexibility.

```